### PR TITLE
move babel-cli to dev and es2015 presets to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riq-babel-register",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "babel require hook with relative caching",
   "license": "MIT",
   "repository": "https://github.com/RivalIQ/riq-babel-register",
@@ -10,11 +10,8 @@
     "prepublish": "babel src --out-dir lib"
   },
   "dependencies": {
-    "babel-cli": "^6.7.7",
-    "babel-core": "^6.7.2",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "babel-runtime": "^5.0.0",
+    "babel-core": "^6.6.0",
+    "babel-runtime": "^6.6.0",
     "chalk": "^1.1.3",
     "core-js": "^2.1.0",
     "home-or-tmp": "^1.0.0",
@@ -25,8 +22,11 @@
   },
   "babel": {
     "presets": [
-      "es2015",
-      "stage-0"
+      "es2015"
     ]
+  },
+  "devDependencies": {
+    "babel-cli": "^6.6.0",
+    "babel-preset-es2015": "^6.6.0"
   }
 }


### PR DESCRIPTION
Goal 1: Reduce size/install time
- Remove unused stage-0 dependency to reduce dependency size
- Move build dependencies to devDependencies (cutting out babel-cli saves a ton)
- Normalize baseline version of dependencies (will be determined by parent project)

Goal 2: Reduce cache bloat when using relative paths
- store file checksum in the cache results instead of the cache key so cache results are clobbered on change instead of duplicated 
